### PR TITLE
Change header definition to byte instead of fixed constant

### DIFF
--- a/zoomzt2.py
+++ b/zoomzt2.py
@@ -16,7 +16,7 @@ Header = Struct(
     Padding(22),
     "name" / PaddedString(12, "ascii"),
     Padding(6),
-    Const(b"\x01"),
+    Bytes(1),
     Padding(7),
     Const(b"\x3c\x3c\x3c\x00"),
     Padding(22),


### PR DESCRIPTION
As discussed in issue #8, for some strange reason in my pedal this byte was changing between `\x01` and `\x00`. This changed worked for me.