### PR TITLE
Rudimentary support for reading MS-200D+ effect files

### DIFF
--- a/zoomzt2.py
+++ b/zoomzt2.py
@@ -103,6 +103,18 @@ INFO = Struct(
     "dspload" / Float32l,
 )
 
+INF2 = Struct(
+    Const(b"INF2"),
+    "length" / Int32ul,
+    "data" / Bytes(this.length),
+)
+
+CCOE = Struct(
+    Const(b"CCOE"),
+    "length" / Int32ul,
+    "data" / Bytes(this.length),
+)
+
 DATA = Struct(
     Const(b"DATA"),
     "length" / Int32ul,
@@ -160,7 +172,9 @@ ZD2 = Struct(
     "TXJ1" / TXJ1,
     "TXE1" / TXE1,
     "INFO" / INFO,
-    "DATA" / DATA,
+    "INF2" / Optional(INF2),
+    "CCOE" / Optional(CCOE),
+    "DATA" / Optional(DATA),
 
     # these do not appear in the effects from AC-2 and AC-3
     "PRMJ" / Optional(PRMJ),


### PR DESCRIPTION
Some (but not all) of the ZD2 files for the MS-200D+ have INF2 and CCOE chunks, and are missing the DATA chunk. decode_effect.py would fail when reading these files.

With this small fix, decode_effect.py is able to decode these ZD2 effect files from MS-200D+. 

Example: python .\decode_effect.py --dump MS200DPLUS\COEHC2G8.ZD2

I have not made any attempt at figuring out the contents of these two new chunks.